### PR TITLE
fix: checkout to docs repo before build

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           repository: jina-ai/jina
           token: ${{ secrets.JINA_DEV_BOT }}
-      - name: Install released version and Build docs
+      - name: Install released Jina version
         run: |
           pip install .  --no-cache-dir
           JINA_VERSION=$(sed -n '/^__version__/p' ./jina/__init__.py | cut -d \' -f2)-master

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -21,7 +21,11 @@ jobs:
           pip install .  --no-cache-dir
           JINA_VERSION=$(sed -n '/^__version__/p' ./jina/__init__.py | cut -d \' -f2)-master
           echo "JINA_VERSION=${JINA_VERSION}" >> $GITHUB_ENV
-          echo -e "${JINA_VERSION}" >> versions
+      - name: Checkout to docs repo
+        uses: actions/checkout@v2
+      - name: Build docs
+        run: |
+          echo -e "${{env.JINA_VERSION}}" >> versions
           bash .github/scripts/make-doc.sh release "release ${{env.JINA_VERSION}} of ${{github.repository}}"
       - name: Commit documentation changes to gh-pages
         run: |


### PR DESCRIPTION
We received a Jina-RELEASE-EVENT and workflow reported an error:
> bash: .github/scripts/make-doc.sh: No such file or directory

This PR checkout back to docs repo and run `make-doc.sh`.