### PR TITLE
docs: update flow docs

### DIFF
--- a/chapters/flow/index.md
+++ b/chapters/flow/index.md
@@ -1,23 +1,35 @@
 ## Using Flow API to Compose Your Jina Workflow
 
-##### Summary: In this section, you will get to know how to construct the flow using different approaches. 
+In this section, you will get to know how to construct the flow using different approaches. 
 
+Table of Contents
+- [Using Flow API to Compose Your Jina Workflow](#using-flow-api-to-compose-your-jina-workflow)
+  * [Feature description and expected outcome](#feature-description-and-expected-outcome)
+  * [Before you start](#before-you-start)
+  * [Implementation](#implementation)
+    + [Use Flow API in Python](#use-flow-api-in-python)
+      - [Create a Flow](#create-a-flow)
+      - [Add Pod into the Flow](#add-pod-into-the-flow)
+      - [Add a Containerized Pod into the Flow](#add-a-containerized-pod-into-the-flow)
+      - [Add a Remote Pod into the Flow](#add-a-remote-pod-into-the-flow)
+      - [Add a Remote Containerized Pod into the Flow](#add-a-remote-containerized-pod-into-the-flow)
+      - [Parallelize the Steps](#parallelize-the-steps)
+      - [Waiting for Parallel Steps to Finish](#waiting-for-parallel-steps-to-finish)
+      - [Run a Flow](#run-a-flow)
+      - [Test Connectivity with Dry Run](#test-connectivity-with-dry-run)
+      - [Iterate over Pods in the Flow](#iterate-over-pods-in-the-flow)
+      - [Feed Data to the Flow](#feed-data-to-the-flow)
+      - [Feed Data to the Flow from Other Clients](#feed-data-to-the-flow-from-other-clients)
+    + [Use Flow API in YAML](#use-flow-api-in-yaml)
+      - [Load a Flow from YAML](#load-a-flow-from-yaml)
+    + [Design a Flow with Dashboard](#design-a-flow-with-dashboard)
+    
 ### Feature description and expected outcome
 In search systems, tasks such as indexing often involve multiple steps: preprocessing, encoding, storing, etc. In Jina's architecture, each step is implemented by an Executor and wrapped by a Pod. This microservice design makes the whole pipeline flexible and scalable. Accomplishing a task is then linking all these Pods to work together, either sequentially or in parallel; locally or remotely. 
 
 The Flow API is a context manager for Pods. Each `Flow` object corresponds to a real-world task. It helps the user to manage the states and contexts of all Pods required in that task. The Flow API translates a workflow defined in Python code, YAML file, or interactive graph to a runtime backed by multi-thread/process, Kubernetes, Docker Swarm, etc. Users don't need to worry about where the Pod is running or how the Pods are connected.
 
 ![Flow is a context manager](flow-api-doc.png)
-
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
-
-- [Use Flow API in Python](#use-flow-api-in-python)
-- [Use Flow API in YAML](#use-flow-api-in-yaml)
-- [Design a Flow with Dashboard](#design-a-flow-with-dashboard)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ### Before you start
 Make sure you install latest version of Jina via [Installation](https://docs.jina.ai/chapters/install/os/index.html).

--- a/chapters/flow/index.md
+++ b/chapters/flow/index.md
@@ -73,7 +73,7 @@ Besides the file path, in Flow API `uses` can accept other types:
 | Type | Example | Remark |
 | --- | --- | --- |
 | YAML file path | `crafter/my.yml` | |
-| Inline YAML | `- !Buffer2URI \| {mimetype: png}` | Don't forget `- !` in the beginning |
+| Inline YAML | `- !Buffer2URI | {mimetype: png}` | Don't forget `- !` in the beginning |
 | The name of an executor [listed here](../all_exec.html) | `NumpyIndexer` | Only the executors that have full default values can be directly used |
 | Built-in simple executors [listed here](../simple_exec.html) | `_clear` | Always starts with `_` |
 | Docker image | `docker://jinahub/pod.encoder.dummy_mwu_encoder:0.0.6-0.9.3` | Add `docker://` before the image name and set timeout_ready to -1 to avoid timeout error |
@@ -164,8 +164,11 @@ gateway -> p1 -> p2 ->
 To run a Flow, simply use the `with` keyword:
 
 ```python
-f = (Flow().add(...)
-           .add(...))
+
+f = (Flow().add(name='p1')
+           .add(name='p2')
+           .add(name='p3', needs='p1')
+           .join(['p2', 'p3']))
 
 with f:
     # the flow is now running
@@ -185,7 +188,22 @@ with f:
 
 ```
 
-This will send a `ControRequest` to all pods following the topology you defined. You can use it to test the connectivity of all pods. 
+##### Iterate over Pods in the Flow
+
+You can iterate the Pods in a Flow like you would a list. For example:
+
+```python
+
+f = (Flow().add(name='p1')
+           .add(name='p2')
+           .add(name='p3', needs='p1')
+           .join(['p2', 'p3']))
+
+for p in f.build():
+    print(f'name: {p[0]} in: {str(p[1].args.socket_in)} out: {str(p[1].args.socket_out)}')
+
+```
+Note f.build() will build the underlying network context but not run the Pods. It is very useful for debugging.
 
 ##### Feed Data to the Flow
 

--- a/chapters/flow/index.md
+++ b/chapters/flow/index.md
@@ -1,5 +1,8 @@
-# Using Flow API to Compose Your Jina Workflow
+## Using Flow API to Compose Your Jina Workflow
 
+##### Summary: In this section, you will get to know how to construct the flow via different approaches. 
+
+### Feature description and expected outcome
 In search systems, tasks such as indexing often involve multiple steps: preprocessing, encoding, storing, etc. In Jina's architecture, each step is implemented by an Executor and wrapped by a Pod. This microservice design makes the whole pipeline flexible and scalable. Accomplishing a task is then orchestrating all these Pods to work together, either sequentially or in parallel; locally or remotely. 
 
 The Flow API is a context manager for Pods. Each `Flow` object corresponds to a real-world task. It helps the user to manage the states and contexts of all Pods required in that task. The Flow API translates a workflow defined in Python code, YAML file, or interactive graph to a runtime backed by multi-thread/process, Kubernetes, Docker Swarm, etc. Users don't need to worry about where the Pod is running or how the Pods are connected.
@@ -16,11 +19,14 @@ The Flow API is a context manager for Pods. Each `Flow` object corresponds to a 
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
+### Before you start
+Make sure you install latest version of Jina via [Installation](https://docs.jina.ai/chapters/install/os/index.html).
 
+### Implementation
 
-## Use Flow API in Python
+#### Use Flow API in Python
 
-### Create a Flow 
+##### Create a Flow 
 
 To create a new Flow:
 
@@ -30,7 +36,7 @@ from jina.flow import Flow
 f = Flow()
 ```
 
-`Flow()` accepts some arguments, see `jina flow --help` or [our documentation](https://docs.jina.ai) for details. For example, `Flow(log_server=True)` will enable sending logs to the [dashboard](https://github.com/jina-ai/dashboard). 
+`Flow()` accepts some arguments, see `jina flow --help` or check [here](https://docs.jina.ai/chapters/cli/jina-flow.html) for details. 
 
 When the arguments given to `Flow()` cannot be parsed, they are propagated to all the Flow's `Pods` for parsing (if they are accepted, see `jina pod --help` for the list of arguments). For example:
 
@@ -40,7 +46,7 @@ f = Flow(read_only=True)
 
 will set the `read_only` attribute of all Pods in `f` to `True`.
 
-### Add Pod into the Flow
+##### Add Pod into the Flow
 
 To add a Pod to the Flow, simply call `.add()`:
 
@@ -67,24 +73,24 @@ Besides the file path, in Flow API `uses` can accept other types:
 | Type | Example | Remark |
 | --- | --- | --- |
 | YAML file path | `crafter/my.yml` | |
-| Inline YAML | `'!DataURICrafter\nwith: {mimetype: png}'` | don't forget `!` in the beginning |
-| The name of an executor [listed here](../all_exec.html) | `TransformerTorchEncoder` | only the executors that have full default values can be directly used |
+| Inline YAML | `- !Buffer2URI \| {mimetype: png}` | Don't forget `- !` in the beginning |
+| The name of an executor [listed here](../all_exec.html) | `NumpyIndexer` | Only the executors that have full default values can be directly used |
 | Built-in simple executors [listed here](../simple_exec.html) | `_clear` | Always starts with `_` |
-| Docker image | `docker://jinahub/pod.encoder.dummy_mwu_encoder:0.0.6-0.9.3` | Add `docker://` before the image name |
+| Docker image | `docker://jinahub/pod.encoder.dummy_mwu_encoder:0.0.6-0.9.3` | Add `docker://` before the image name and set timeout_ready to -1 to avoid timeout error |
  
-#### Add a Containerized Pod into the Flow
+##### Add a Containerized Pod into the Flow
 
 To run a Pod in a Docker container, simply specify the `image` argument:
 
 ```python
 f = (Flow().add(name='p1')
-           .add(name='p2', image='jinaai/hub.executors.encoders.bidaf:latest')
+           .add(name='p2', image='jinaai/hub.examples.mwu_encoder:latest')
            .add(name='p3'))
 ``` 
 
-This will run `p2` in a Docker container equipped with the image `jinaai/hub.executors.encoders.bidaf:latest`. More information on using containerized Pod can be found [here](https://docs.jina.ai/chapters/hub/index.html). 
+This will run `p2` in a Docker container equipped with the image `jinaai/hub.examples.mwu_encoder:latest`. More information on using containerized Pod can be found [here](https://docs.jina.ai/chapters/hub/index.html). 
 
-#### Add a Remote Pod into the Flow
+##### Add a Remote Pod into the Flow
 
 To run a Pod remotely, simply specify the `host` and `port_expose` arguments. For example:
 
@@ -99,7 +105,7 @@ This will start `p2` remotely on `192.168.0.100`, whereas `p1` and `p3` run loca
 To use remote Pods, you need to start a `gateway` on `192.168.0.100` in advance. More information on using remote Pods can be found [here](https://docs.jina.ai/chapters/remote/index.html).  
 
 
-#### Add a Remote Containerized Pod into the Flow
+##### Add a Remote Containerized Pod into the Flow
 
 A very useful pattern is to combine the above two features together:
 
@@ -107,7 +113,7 @@ A very useful pattern is to combine the above two features together:
 
 f = (Flow().add(name='p1')
            .add(name='p2', host='192.168.0.100', port_expose=53100,
-                image='jinaai/hub.executors.encoders.bidaf:latest')
+                image='jinaai/hub.examples.mwu_encoder:latest')
            .add(name='p3'))
 ```
 
@@ -115,7 +121,7 @@ This will start `p2` remotely on `192.168.0.100` running a Docker container equi
 
 
 
-### Parallelize the Steps
+##### Parallelize the Steps
 
 By default, if you keep adding `.add()` to a `Flow`, it will create a long chain of sequential workflow. You can parallelize some of the steps by using `needs` argument. For example,
 
@@ -132,7 +138,7 @@ gateway -> p1 -> p2
               -> p3 -> gateway 
 ```
 
-### Waiting for Parallel Steps to Finish
+##### Waiting for Parallel Steps to Finish
 
 In the prior example, the message is returned to the gateway regardless of the status of `p2`. To wait for multiple parallel steps to finish before continuing, you can do:
 
@@ -153,7 +159,7 @@ gateway -> p1 -> p2 ->
 
 
 
-### Run a Flow
+##### Run a Flow
 
 To run a Flow, simply use the `with` keyword:
 
@@ -168,34 +174,20 @@ with f:
 
 Though you can manually call the `start()` method to run the flow, you also need to call the corresponding `close()` method to release the resource. Using `with` saves you the trouble, as the resource is automatically released when running out of the scope. 
 
-#### Test Connectivity with Dry Run
+##### Test Connectivity with Dry Run
 
-You can test the whole workflow with `dry_run()`. For example:
+You can test the whole workflow with `pass`. For example:
 
 ```python
 
 with f:
-    f.dry_run()
+    pass
 
 ```
 
 This will send a `ControRequest` to all pods following the topology you defined. You can use it to test the connectivity of all pods. 
 
-### Iterate over Pods in the Flow
-
-You can iterate the Pods in a Flow like you would a list:
-
-```python
-f = (Flow().add(...)
-           .add(...))
-
-for p in f.build():
-    print(f'{p.name} in: {str(p.head_args.socket_in)} out: {str(p.head_args.socket_out)}')
-```
-
-Note `f.build()` will build the underlying network context but not run the Pods. It is very useful for debugging.
-
-### Feed Data to the Flow
+##### Feed Data to the Flow
 
 You can use `.index()`, `.search()` to feed index data and search query to a Flow:
 
@@ -226,7 +218,7 @@ input_fn = (b's' for _ in range(10))
 
 > Please note that the current Flow API does not support using `index()` and `search()` together in the same `with` scope. This is because the workflow of `index()` and `search()` are usually different, and you cannot use one workflow for both tasks.
 
-#### Feed Data to the Flow from Other Clients
+##### Feed Data to the Flow from Other Clients
 
 If you don't use Python as a client, or your client and Flow are in different instances, you can keep a Flow running and use a client in another language to connect to it:
 
@@ -245,57 +237,42 @@ with f:
         pass # <- dont do that
 ```
 
-## Use Flow API in YAML
+#### Use Flow API in YAML
 
 You can also write a Flow in YAML:
 
 ```yaml
 !Flow
+version: '1.0'
+with:
+    restful: true
 pods:
-  chunk_seg:
-    uses: craft/index-craft.yml
-    replicas: $REPLICAS
-    read_only: true
-  doc_idx:
-    uses: index/doc.yml
-  tf_encode:
-    uses: encode/encode.yml
-    needs: chunk_seg
-    replicas: $REPLICAS
-    read_only: true
-  chunk_idx:
-    uses: index/chunk.yml
-    replicas: $SHARDS
-  join_all:
+  - name: pod0  # notice the change here, name is now an attribute
+    method: add  # by default method is always add, available: add, needs, inspect
     uses: _pass
-    needs: [doc_idx, chunk_idx]
-    read_only: true
+    needs: gateway
+  - name: pod1  # notice the change here, name is now an attribute
+    method: add  # by default method is always add, available: add, needs, inspect
+    uses: _pass
+    needs: gateway
+  - method: inspect  # add an inspect node on pod1
+  - method: needs  # let's try something new in Flow YAML v1: needs
+    needs: [pod1, pod0]
 ```
 
-You can use enviroment variables with `$` in YAML. More information on the Flow YAML Schema can be found in [our documentation](https://docs.jina.ai). 
+You can use enviroment variables with `$` in YAML. More information on the Flow YAML Schema can be found [here](https://docs.jina.ai/chapters/yaml/index.html). 
 
-### Load a Flow from YAML
+##### Load a Flow from YAML
 
 ```python
 from jina.flow import Flow
 f = Flow.load_config('myflow.yml')
 ```
 
-### Start a Flow Directly from the CLI
 
-The following command will start a Flow from the console and hold it for a client to connect.
+#### Design a Flow with Dashboard
 
-```bash
-jina flow --yaml-path myflow.yml
-``` 
-
-
-## Design a Flow with Dashboard
-
-With Jina Dashboard, you can interactively drag and drop Pods, set their attribute and export to a Flow YAML file.  
-
-![Dashboard](flow-demo.gif)
-
+With Jina Dashboard, you can interactively drag and drop Pods, set their attribute and export to a Flow YAML file.
 
 More information on the dashboard can be found [here](https://github.com/jina-ai/dashboard).
 

--- a/chapters/flow/index.md
+++ b/chapters/flow/index.md
@@ -3,7 +3,7 @@
 ##### Summary: In this section, you will get to know how to construct the flow using different approaches. 
 
 ### Feature description and expected outcome
-In search systems, tasks such as indexing often involve multiple steps: preprocessing, encoding, storing, etc. In Jina's architecture, each step is implemented by an Executor and wrapped by a Pod. This microservice design makes the whole pipeline flexible and scalable. Accomplishing a task is then orchestrating all these Pods to work together, either sequentially or in parallel; locally or remotely. 
+In search systems, tasks such as indexing often involve multiple steps: preprocessing, encoding, storing, etc. In Jina's architecture, each step is implemented by an Executor and wrapped by a Pod. This microservice design makes the whole pipeline flexible and scalable. Accomplishing a task is then linking all these Pods to work together, either sequentially or in parallel; locally or remotely. 
 
 The Flow API is a context manager for Pods. Each `Flow` object corresponds to a real-world task. It helps the user to manage the states and contexts of all Pods required in that task. The Flow API translates a workflow defined in Python code, YAML file, or interactive graph to a runtime backed by multi-thread/process, Kubernetes, Docker Swarm, etc. Users don't need to worry about where the Pod is running or how the Pods are connected.
 

--- a/chapters/flow/index.md
+++ b/chapters/flow/index.md
@@ -1,6 +1,6 @@
 ## Using Flow API to Compose Your Jina Workflow
 
-##### Summary: In this section, you will get to know how to construct the flow via different approaches. 
+##### Summary: In this section, you will get to know how to construct the flow using different approaches. 
 
 ### Feature description and expected outcome
 In search systems, tasks such as indexing often involve multiple steps: preprocessing, encoding, storing, etc. In Jina's architecture, each step is implemented by an Executor and wrapped by a Pod. This microservice design makes the whole pipeline flexible and scalable. Accomplishing a task is then orchestrating all these Pods to work together, either sequentially or in parallel; locally or remotely. 
@@ -36,7 +36,7 @@ from jina.flow import Flow
 f = Flow()
 ```
 
-`Flow()` accepts some arguments, see `jina flow --help` or check [here](https://docs.jina.ai/chapters/cli/jina-flow.html) for details. 
+`Flow()` accepts some arguments. See `jina flow --help` or check [here](https://docs.jina.ai/chapters/cli/jina-flow.html) for details. 
 
 When the arguments given to `Flow()` cannot be parsed, they are propagated to all the Flow's `Pods` for parsing (if they are accepted, see `jina pod --help` for the list of arguments). For example:
 
@@ -48,7 +48,7 @@ will set the `read_only` attribute of all Pods in `f` to `True`.
 
 ##### Add Pod into the Flow
 
-To add a Pod to the Flow, simply call `.add()`, syntax of Yaml file can be found [here](https://docs.jina.ai/chapters/yaml/index.html):
+To add a Pod to the Flow, simply call `.add()`, syntax of YAML file can be found [here](https://docs.jina.ai/chapters/yaml/index.html):
 
 ```python
 f = (Flow().add(name='p1', uses='mypod1.yml')
@@ -123,7 +123,7 @@ This will start `p2` remotely on `192.168.0.100` running a Docker container equi
 
 ##### Parallelize the Steps
 
-By default, if you keep adding `.add()` to a `Flow`, it will create a long chain of sequential workflow. You can parallelize some of the steps by using `needs` argument. For example,
+By default, if you keep adding `.add()` to a `Flow`, it will create a sequential workflow chain. You can parallelize some of the steps by using `needs` argument. For example,
 
 ```python
 f = (Flow().add(name='p1')

--- a/chapters/flow/index.md
+++ b/chapters/flow/index.md
@@ -48,7 +48,7 @@ will set the `read_only` attribute of all Pods in `f` to `True`.
 
 ##### Add Pod into the Flow
 
-To add a Pod to the Flow, simply call `.add()`:
+To add a Pod to the Flow, simply call `.add()`, syntax of Yaml file can be found [here](https://docs.jina.ai/chapters/yaml/index.html):
 
 ```python
 f = (Flow().add(name='p1', uses='mypod1.yml')


### PR DESCRIPTION
Major changes:
- [x] Reformat the structure to follow guide
- [x] Remove dashboard graphics
- [x] log_server parameter setting for Flow is removed
- [x] Add yaml syntax for 'Add Pod into the Flow'
- [x] update `uses` API
- [x] update 'jinaai/hub.executors.encoders.bidaf:latest' to 'jinaai/hub.examples.mwu_encoder:latest'
- [x] replace f.dry_run() with pass
- [x] Iterate over Pods in the Flow→removed
- [x] Use Flow API in YAML→ updated to version 1
- [x] Start a Flow Directly from the CLI→outdated and removed
- [ ] wait for new layout