### PR TITLE
fix: revert changes on make doc bash scripts

### DIFF
--- a/.github/scripts/make-doc.sh
+++ b/.github/scripts/make-doc.sh
@@ -43,9 +43,8 @@ if [[ $1 == "commit" ]]; then
   cp README.md .github/artworks/jinahub.jpg .github/artworks/jina-logo-dark.png _build/html/
   cd -
   cd ${HTML_DIR}
-  rm -rf master
-  mkdir -p master
-  rsync -avr --ignore-missing-args . master  # sync everything under the root to master/
+  mkdir  master
+  rsync -avr . master  # sync everything under the root to master/
   cd -
   cd ${DOC_DIR}/bak
   rsync -avr --ignore-missing-args ./v* ../_build/html/ --ignore-existing  # revert backup back
@@ -77,6 +76,7 @@ elif [[ $1 == "release" ]]; then
   cd ${HTML_DIR}
   rm -rf bak
   echo docs.jina.ai > CNAME
+  echo -e "${RELEASE_VER}" >> versions
   git init
   git config --local user.email "dev-bot@jina.ai"
   git config --local user.name "Jina Dev Bot"

--- a/.github/scripts/make-doc.sh
+++ b/.github/scripts/make-doc.sh
@@ -43,7 +43,7 @@ if [[ $1 == "commit" ]]; then
   cp README.md .github/artworks/jinahub.jpg .github/artworks/jina-logo-dark.png _build/html/
   cd -
   cd ${HTML_DIR}
-  mkdir  master
+  mkdir master
   rsync -avr . master  # sync everything under the root to master/
   cd -
   cd ${DOC_DIR}/bak

--- a/.github/scripts/make-doc.sh
+++ b/.github/scripts/make-doc.sh
@@ -64,6 +64,7 @@ if [[ $1 == "commit" ]]; then
 elif [[ $1 == "release" ]]; then
   cd ${DOC_DIR}
   cp README.md .github/artworks/jinahub.jpg .github/artworks/jina-logo-dark.png _build/html/
+  echo -e "${RELEASE_VER}" >> versions
   cd -
   cd ${HTML_DIR}
   rsync -avr . master  # sync everything under the root to master/
@@ -76,7 +77,6 @@ elif [[ $1 == "release" ]]; then
   cd ${HTML_DIR}
   rm -rf bak
   echo docs.jina.ai > CNAME
-  echo -e "${RELEASE_VER}" >> versions
   git init
   git config --local user.email "dev-bot@jina.ai"
   git config --local user.name "Jina Dev Bot"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -25,18 +25,6 @@ jobs:
           echo "RELEASE_VER=${RELEASE_VER}" >> $GITHUB_ENV
       - name: Checkout to docs repo
         uses: actions/checkout@v2
-      - name: Commit release version to the current branch
-        run: |
-          echo -e "${{env.RELEASE_VER}}" >> versions
-          git config --local user.email "dev-bot@jina.ai"
-          git config --local user.name "Jina Dev Bot"
-          git add versions
-          git commit -m "update ${{env.RELEASE_VER}} on ${{github.repository}}" -a || true
-      - name: Push versions to the current branch
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.JINA_DEV_BOT }}
-          branch: ${{ github.ref }}
       - name: Build docs
         run: |
           bash .github/scripts/make-doc.sh release "release ${{env.JINA_VERSION}} of ${{github.repository}}"


### PR DESCRIPTION
Fix the broken pipeline of jina release and jina merge.

1. revert #37 and #34 for new layout pr.
2. Jina failed to release because `master` is protected branch, failed to commit `versions` directly to `master` branch, move the operation to `make-doc.sh`.