### PR TITLE
fix: remove mkdir from commit script

### DIFF
--- a/.github/scripts/make-doc.sh
+++ b/.github/scripts/make-doc.sh
@@ -43,7 +43,6 @@ if [[ $1 == "commit" ]]; then
   cp README.md .github/artworks/jinahub.jpg .github/artworks/jina-logo-dark.png _build/html/
   cd -
   cd ${HTML_DIR}
-  mkdir master
   rsync -avr . master  # sync everything under the root to master/
   cd -
   cd ${DOC_DIR}/bak


### PR DESCRIPTION
Remove `mkdir` to avoid create folders recursively. 