### PR TITLE
feat: add links for daemon and jina openapi spec

### DIFF
--- a/chapters/daemon/index.rst
+++ b/chapters/daemon/index.rst
@@ -1,0 +1,6 @@
+Jina Daemon API Specification
+=============================
+
+Link to Jina Daemon OpenAPI Specification <https://api.jina.ai/daemon/>
+
+This is a REST interface for managing distributed Jina

--- a/chapters/rest-reference/index.rst
+++ b/chapters/rest-reference/index.rst
@@ -1,0 +1,4 @@
+Jina OpenAPI Specification
+=============================
+
+Link to Jina OpenAPI API reference <https://api.jina.ai/rest/>


### PR DESCRIPTION
API reference Links to:

-  `api.jina.ai/daemon`
- `api.jina.ai/rest`