### PR TITLE
ci: install latest jina to build latest docstring

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,7 +24,6 @@ jobs:
           python-version: 3.8
       - name: Get Jina version
         run: |
-          pip install jina
           JINA_VERSION=$(sed -n '/^__version__/p' ./jina/__init__.py | cut -d \' -f2)-master
           echo "JINA_VERSION=${JINA_VERSION}" >> $GITHUB_ENV
       - name: Checkout to docs repo

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,6 +24,7 @@ jobs:
           python-version: 3.8
       - name: Get Jina version
         run: |
+          pip install .  --no-cache-dir
           JINA_VERSION=$(sed -n '/^__version__/p' ./jina/__init__.py | cut -d \' -f2)-master
           echo "JINA_VERSION=${JINA_VERSION}" >> $GITHUB_ENV
       - name: Checkout to docs repo


### PR DESCRIPTION
Problem definition: when building docstrings, we install released version (on pypi) of jina. While we should use the `master` branch of jina to see the latest updates in docstring changes.