### PR TITLE
fix(ci): checkout to docs before pr

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -50,6 +50,11 @@ jobs:
     needs: releaseJob
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout to Jina docs
+        uses: actions/checkout@v2
+        with:
+          repository: jina-ai/docs
+          token: ${{ secrets.JINA_DEV_BOT }}
       - name: Update CHANGELOG, RELEASE, versions
         run: |
           wget https://raw.githubusercontent.com/jina-ai/jina/master/CONTRIBUTING.md -P ./chapters/


### PR DESCRIPTION
Fix post release job error. Before commit, checkout to docs repo.

![image](https://user-images.githubusercontent.com/9794489/110268171-87e0bb80-7fc1-11eb-9f08-01b03f596110.png)
