### PR TITLE
feat: add release drafter and pr labeler

### DIFF
--- a/.github/pr_labeler.yml
+++ b/.github/pr_labeler.yml
@@ -1,0 +1,7 @@
+fix: ['fix/*', 'bug/*']
+chore: chore/*
+documentation: docs/*
+priority: priority/*
+status: status/*
+type: type/*
+

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,26 @@
+categories:
+  - title: 'Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: 'Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: 'Maintenance'
+    label: 
+      - 'chore'
+      - 'dependencies'
+  - title: 'Documentation'
+    label: 
+      - 'documentation'
+
+exclude-labels:
+  - 'skip-release-drafter'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  ## Changes
+
+  $CHANGES
+


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [documentation style guide](https://github.com/jina-ai/docs/tree/master/page_templates/style_guide.md)? 

## Description
Adding release-drafter and pull requests labeler. 
Issue Reference #178 

## Motivation and Context
The motivation is that once the release drafter automates the releases and the log files for each release is automated and released as notes, it can give a better picture of the distinction of the new updates in each release based on the bug fixes, documentation, feature enhancements. Have added more labels and a greater classification of the labels. 

## How Has This Been Tested?
This has been tested on a local repository. 