### PR TITLE
docs: fix title too short warning

### DIFF
--- a/chapters/cli/exit.rst
+++ b/chapters/cli/exit.rst
@@ -1,6 +1,6 @@
-====================
+==========================
 How to Correctly Exit Jina
-====================
+==========================
 
 In this section, you will learn best practices for shutting down a Flow and exiting Jina correctly.
 

--- a/chapters/cross_multi_modality.rst
+++ b/chapters/cross_multi_modality.rst
@@ -1,6 +1,6 @@
-==========================================
+=========================================================
 Understanding Multi-modal and Cross-modal Search in Jina
-==========================================
+=========================================================
 
 .. meta::
    :description: Multi-modal and cross-modal search in Jina

--- a/chapters/executors.rst
+++ b/chapters/executors.rst
@@ -1,6 +1,6 @@
-==========================================
+================================================
 Understanding Jina Executors and How to Use Them
-==========================================
+================================================
 
 .. meta::
    :description: A Guide on What Are Jina Executors and How to Use Them

--- a/chapters/extend/mwu.rst
+++ b/chapters/extend/mwu.rst
@@ -1,5 +1,5 @@
 A Minimum Working Example of Jina
-=========================
+=================================
 
 This dummy encoder embeds everything to a 3-dimensional vector. You only need two files:
 

--- a/chapters/incremental_indexing.rst
+++ b/chapters/incremental_indexing.rst
@@ -1,5 +1,5 @@
 How to Use Incremental Indexing
-====================
+================================
 
 Summary
 -------

--- a/chapters/input_output.rst
+++ b/chapters/input_output.rst
@@ -1,5 +1,5 @@
 How to handle Inputs and Outputs for Flows
-========================================
+==========================================
 
 This chapter explains how input and output data is handled by the ``Flow API``.
 

--- a/chapters/logging.rst
+++ b/chapters/logging.rst
@@ -23,7 +23,7 @@ Overview
 -------------------
 
 Jina logging messages at first glance
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Let's start from an logging example. Jina logs messages with different formats in different situations. The example below follows the most commonly used format:
 

--- a/chapters/prevent_duplicate_indexing.rst
+++ b/chapters/prevent_duplicate_indexing.rst
@@ -1,5 +1,5 @@
 How to Prevent Duplicate Indexing
-===========================
+=================================
 
 Summary
 -------

--- a/chapters/project_guide.rst
+++ b/chapters/project_guide.rst
@@ -1,6 +1,6 @@
-#####################
+############################
 How to Set up Jina Correctly
-#####################
+############################
 
 .. meta::
    :description: You will see the best practices on how to create a project on Jina.

--- a/chapters/ranker.rst
+++ b/chapters/ranker.rst
@@ -165,7 +165,7 @@ Run with Jina CLI
 
 
 Conventional local usage with uses argument (YAML configuration)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. highlight:: bash
 .. code-block:: bash

--- a/chapters/request_size.rst
+++ b/chapters/request_size.rst
@@ -79,7 +79,7 @@ For this example, we will index 100 ``Documents`` and use 10 parallel :term:`Cra
 
 
 Choosing different request size
-------------------------------
+--------------------------------
 Different settings of ``request_size`` may influence the running performance. A higher value means a large number ``Documents`` will be fed into the :term:`Pea` and will demand more memory. A lower value will decrease the cost of memory but may increase the running time since we need to send more ``requests``.
 
 A simple extension of the above example generates a box plot showing the relationship between ``request_size`` and running time when we have 100 ``Documents`` to be indexed. This may help you to get more insights on choosing the ``request_size``.


### PR DESCRIPTION
this pr should fix all title too short warnings in docs repo.