### PR TITLE
docs: fix typos in 101 and io

### DIFF
--- a/chapters/101.rst
+++ b/chapters/101.rst
@@ -49,7 +49,7 @@ Flows manage the two main search workflows: indexing data (indexing Flow) and th
 A Flow is made up of several sub-tasks, and it manages the states and context of these sub-tasks. The input and output data of Flows are Documents.
 It is a high level concept in Jina, representing a sequence of steps for accomplishing a task.
 
-You can add logic to the Flow by using `add` message and create parallelization using `needs` method. Once the Flow is built you can open it like opening a file in Python and then fit data into it.
+You can add logic to the Flow by using `add` message and create parallelization using `needs` method. Once the Flow is built you can open it like opening a file in Python and then feed data into it.
 
 Jina Flow is fully decentralized and can be fully distributed on the cloud. You can simply distribute a part of the Flow by setting the host to a remote address. You can also containerize a Flow either partially or completely. Besides building a Flow from Python, you can also build a Flow from a yaml config - this creates a separation between the code base and the configuration
 which could be extremely useful when conducting a test. 

--- a/chapters/input_output.rst
+++ b/chapters/input_output.rst
@@ -6,7 +6,7 @@ This chapter explains how input and output data is handled by the ``Flow API``.
 Input
 -----
 The input data for the ``Flow`` functions ``flow.index(...)``, ``flow.update(...)`` and ``flow.search(...)`` can be provided in three different ways.
-In the following example, the input functionality is shown using the ``Flor.index(...)`` function.
+In the following example, the input functionality is shown using the ``flow.index(...)`` function.
 For ``flow.update(...)`` and ``flow.search(...)``, the input is provided the same way.
 
 #. A single ``Document`` can be sent through the ``Flow`` as shown below.


### PR DESCRIPTION
Fixing two minor typos in the docs in 101 and IO chapter.