### PR TITLE
docs(install): refactor, reduce needed clicks

### DIFF
--- a/chapters/core/setup/index.rst
+++ b/chapters/core/setup/index.rst
@@ -12,7 +12,10 @@ Below you will find the setup guides for various, selected environments.
    :glob:
 
    ../../install/index
-   ../../install/ide-speedup
+   ../../install/os/via-pip
+   ../../install/os/via-docker
+   ../../install/os/on-rasp-linux
+   ../../install/os/on-wsl
+   ../../install/oson-x
 
-.. note:: You can use Jina without even installing it via `Google Colab
-https://jina.ai/2021/03/17/Jina-now-with-Google-Colab.html`_.
+.. note:: You can use Jina without even installing it via `Google Colab https://jina.ai/2021/03/17/Jina-now-with-Google-Colab.html`_.

--- a/chapters/install/index.rst
+++ b/chapters/install/index.rst
@@ -1,10 +1,12 @@
 Installation
 ======================================
 
-Install using `pip`
+.. note:: You can use Jina without even installing it via `Google Colab <https://jina.ai/2021/03/17/Jina-now-with-Google-Colab.html>`_.
+
+Install on Mac/Linux using ``pip``
 -------------------
 
-To install Jina using Python's package manager, pip, simply run:
+To install using Python's package manager, pip, simply run:
 
 .. code-block:: bash
 

--- a/chapters/install/index.rst
+++ b/chapters/install/index.rst
@@ -1,10 +1,46 @@
-Installing Jina Core
+Installation
 ======================================
 
+Install using `pip`
+-------------------
+
+To install Jina using Python's package manager, pip, simply run:
+
+.. code-block:: bash
+
+   pip install -U jina
+
+`Read more on installing from development version, installing your own fork, cherry-picking dependencies or upgrading Jina`_
+
+Install using Docker
+--------------------
+
+.. code-block:: bash
+
+   docker run jinaai/jina:latest
+
+`Read more on installing from development version, supported architectures`_
+
+Install on Windows
+------------------
+
+Read the `Jina on Windows installation guide`_.
+
+Install on Raspberry Pi
+-----------------------
+
+Read the `Jina on Raspberry Pi installation guide`_
+
 .. toctree::
+   :hidden:
 
    os/via-pip
    os/via-docker
    os/on-rasp-linux
    os/on-wsl
    oson-x
+
+.. _Read more on installing from development version, installing your own fork, cherry-picking dependencies or upgrading Jina: os/via-pip
+.. _Read more on installing from development version, supported architectures: os/via-docker
+.. _Jina on Windows installation guide: os/on-wsl
+.. _Jina on Raspberry Pi installation guide: os/on-rasp-linux

--- a/chapters/install/index.rst
+++ b/chapters/install/index.rst
@@ -24,7 +24,7 @@ Install using Docker
 Install on Windows
 ------------------
 
-Read the `Jina on Windows installation guide`_.
+Jina supports WSL2 on Windows 10. Read the `Jina on Windows installation guide`_.
 
 Install on Raspberry Pi
 -----------------------

--- a/index.rst
+++ b/index.rst
@@ -38,7 +38,7 @@ Table of contents
    :caption: Jina Core
 
    chapters/core/introduction/index
-   chapters/core/setup/index
+   chapters/install/index
    chapters/core/guides/index
    chapters/core/api_references/index
 


### PR DESCRIPTION
Currently a user on docs.jina.ai has to click at least twice (sometimes more) to get to the install instructions:

- Installation -> Install Jina Core via pip

Installation is one of the first things a user wants to do. We should reduce that friction.

Solution: User-friendly install page (no huge lists) with key instructions right there, and links to dig deeper if needed

### All Submissions:

* [x] Have you followed the [documentation style guide](https://github.com/jina-ai/docs/tree/master/page_templates/style_guide.md)? 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Have you added your new file to a table of content index? 
2. [ ] Did you use one of the templates in the [page_template](https://github.com/jina-ai/docs/tree/master/page_templates) folder?
3. [x] Is your title in Title Case? 
4. [x] Are your section headers in sentence case?
