### PR TITLE
feat: add ranker trainer documentation

### DIFF
--- a/chapters/core/guides/index.rst
+++ b/chapters/core/guides/index.rst
@@ -66,6 +66,7 @@ Further information on any specific method can be obtained in the :doc:`../api_r
    ../../evaluation
    ../../optimization
    ../../ranker
+   ../../ranker_trainer
    ../../prevent_duplicate_indexing
    ../../incremental_indexing
    ../../parallel

--- a/chapters/ranker_trainer.rst
+++ b/chapters/ranker_trainer.rst
@@ -25,6 +25,7 @@ Before you start
 -------------------
 
 * This guide assumes you have a good understanding of Jina, if you haven't, please check out `Jina 101 <https://101.jina.ai>`_ first.
+* This guide assumes you have a good understanding of Jina ``Rankers``.
 * This guide assumes you have a good understanding of Machine Learning (Supervised Statistical Learning).
 * You have installed the latest stable release of Jina Core according to the instructions found `here <https://docs.jina.ai/chapters/core/setup/index.html>`_.
 
@@ -38,7 +39,7 @@ Equipped with labels (house price) and features,
 you trained a regression model to predict the house price.
 
 The idea also applies to Search/Retrieval,
-usually reffered to Learning-to-Rank.
+usually referred to Learning-to-Rank.
 The features can be the score of Bm25, #tokens in the document, #links in the document etc,
 the labels are the user annotated relevance score.
 Thus we can train a supervised model to optimise the ``Ranker``.
@@ -47,11 +48,12 @@ In Jina, we created a new type of ``Executor`` named ``RankerTrainer``.
 The ``RankerTrainer`` needs user to implement a `train` and a `save` method.
 The ``train`` method takes a machine learning model to train the ``Ranker``,
 and ``save`` method saves the re-trained model into a directory.
+This feature could be beneficial to continuously improve our ranking model in an incremental manner.
 
-Conclusion
------------------
+Ranker Trainer in Action: Optimize a LightGBMRanker
+---------------------------------------------------
 
-In this guide, we introduced why we need :term:`Rankers` and how to use them. Apart from that, we provided some concrete examples of :term:`Rankers` in use.
+
 
 What's next
 -----------------

--- a/chapters/ranker_trainer.rst
+++ b/chapters/ranker_trainer.rst
@@ -67,7 +67,7 @@ Imaging you're running a online-mall sells shoes, and you want to optimize your 
 The labels are collected `num_clicks` in the past month.
 Your training data might looks like this:
 
-.. list-table:: List of Jina Data Types
+.. list-table:: Sample Training Data
    :widths: 50 25 50 50
    :header-rows: 1
 
@@ -110,6 +110,21 @@ For example:
 Train your model using LightGBMRankerTrainer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+``LightGBMRankerTrainer`` is specifically designed for training a ``LightGBMRanker``.
+While using it, please pass the feature names and label name as well as the parameters in the YAML configuration:
+
+.. highlight:: yaml
+.. code-block:: yaml
+
+    jtype: LightGBMRankerTrainer
+    with:
+      model_path: './lightgbm-model.txt'
+      query_feature_names: ['tags__price', 'tags__size', 'tags__brand']
+      match_feature_names: ['tags__price', 'tags__size', 'tags__brand']
+      label_feature_name: ['tags__relevance']
+    metas:
+      py_modules:
+        - __init__.py
 
 
 

--- a/chapters/ranker_trainer.rst
+++ b/chapters/ranker_trainer.rst
@@ -37,10 +37,16 @@ for each property you designed a list of features, such as #bedrooms, #size, #pr
 Equipped with labels (house price) and features,
 you trained a regression model to predict the house price.
 
-The idea also applies to Search/Retrieval.
+The idea also applies to Search/Retrieval,
+usually reffered to Learning-to-Rank.
+The features can be the score of Bm25, #tokens in the document, #links in the document etc,
+the labels are the user annotated relevance score.
+Thus we can train a supervised model to optimise the ``Ranker``.
 
-
-
+In Jina, we created a new type of ``Executor`` named ``RankerTrainer``.
+The ``RankerTrainer`` needs user to implement a `train` and a `save` method.
+The ``train`` method takes a machine learning model to train the ``Ranker``,
+and ``save`` method saves the re-trained model into a directory.
 
 Conclusion
 -----------------

--- a/chapters/ranker_trainer.rst
+++ b/chapters/ranker_trainer.rst
@@ -6,9 +6,6 @@ A guide on Jina Ranker Trainer
    :description: A guide on Jina Ranker Trainer
    :keywords: Jina, Ranker Trainer
 
-.. note:: This guide assumes you have a basic understanding of Jina, if you haven't, please check out `Jina 101 <https://101.jina.ai>`_ first.
-.. note:: This guide assumes you have a basic understanding of Machine Learning.
-
 .. contents:: Table of Contents
     :depth: 2
 
@@ -21,18 +18,26 @@ For one search request, we may have multiple matches and we want to have the mos
 
 In the Information Retrieval and Machine Learning community,
 researchers has developed Learning-to-Rank technique to allow users to train a ``Ranker`` in a supervised fashion.
-In this guide, we will introduce how to train your ranker with Jina Ranker Trainer.
+In this guide, we will introduce how to train your ``Ranker`` with Jina ``RankerTrainer``.
 
 
 Before you start
 -------------------
 
-You have installed the latest stable release of Jina Core according to the instructions found `here <https://docs.jina.ai/chapters/core/setup/index.html>`_.
+* This guide assumes you have a good understanding of Jina, if you haven't, please check out `Jina 101 <https://101.jina.ai>`_ first.
+* This guide assumes you have a good understanding of Machine Learning (Supervised Statistical Learning).
+* You have installed the latest stable release of Jina Core according to the instructions found `here <https://docs.jina.ai/chapters/core/setup/index.html>`_.
 
 Overview
 -----------------
 
+Imaging you are a data scientist, and working on building a model to predict the house price.
+You collected historical property selling price,
+for each property you designed a list of features, such as #bedrooms, #size, #primary schools near property, #supermarkets near property etc.
+Equipped with labels (house price) and features,
+you trained a regression model to predict the house price.
 
+The idea also applies to Search/Retrieval.
 
 
 

--- a/chapters/ranker_trainer.rst
+++ b/chapters/ranker_trainer.rst
@@ -119,16 +119,20 @@ While using it, please pass the feature names and label name as well as the para
     jtype: LightGBMRankerTrainer
     with:
       model_path: './lightgbm-model.txt'
-      query_feature_names: ['tags__price', 'tags__size', 'tags__brand']
-      match_feature_names: ['tags__price', 'tags__size', 'tags__brand']
-      label_feature_name: ['tags__relevance']
-    metas:
-      py_modules:
-        - __init__.py
+      query_feature_names: ['tags__price', 'tags__brand', 'tags__color']
+      match_feature_names: ['tags__price', 'tags__brand', 'tags__color']
+      label_feature_name: ['tags__num_clicks']
 
+The meaning of these parameters are:
 
+* ``model_path``: The model you want to optimize, if the ``model_path`` does not exist,
+the ranker trainer will train the model from scratch.
+Otherwise will train the model in an incremental manner.
+* ``query_feature_names``: Feature names used to extract from query ``Documents``.
+* ``match_feature_names``: Feature names used to extract from match ``Documents``.
+* ``label_feature_name``: Feature name used to train the model as label.
 
-
+Use this ``Executor`` will trigger ``train`` to use LightGBM to train the model and ``save`` the trained/re-trained model into ``model_path`` as was defined in YAML.
 
 
 What's next

--- a/chapters/ranker_trainer.rst
+++ b/chapters/ranker_trainer.rst
@@ -68,7 +68,7 @@ The labels are collected `num_clicks` in the past month.
 Your training data might looks like this:
 
 .. list-table:: Sample Training Data
-   :widths: 50 25 50 50
+   :widths: 50 50 50 50
    :header-rows: 1
 
    * - price

--- a/chapters/ranker_trainer.rst
+++ b/chapters/ranker_trainer.rst
@@ -137,5 +137,3 @@ What's next
 -----------------
 
 If you still have questions, feel free to `submit an issue <https://github.com/jina-ai/jina/issues>`_ or post a message in our `community slack channel <https://slack.jina.ai>`_ .
-
-To gain a deeper knowledge of the implementation of Jina Ranker, you can find the source code `here <https://github.com/jina-ai/jina/tree/master/jina/executors/rankers>`_.

--- a/chapters/ranker_trainer.rst
+++ b/chapters/ranker_trainer.rst
@@ -65,7 +65,7 @@ The labels are collected `num_clicks` in the past month.
 Your training data might looks like this:
 
 .. list-table:: List of Jina Data Types
-   :widths: 25 25 50
+   :widths: 50 25 50 50
    :header-rows: 1
 
    * - price

--- a/chapters/ranker_trainer.rst
+++ b/chapters/ranker_trainer.rst
@@ -7,6 +7,7 @@ A guide on Jina Ranker Trainer
    :keywords: Jina, Ranker Trainer
 
 .. note:: This guide assumes you have a basic understanding of Jina, if you haven't, please check out `Jina 101 <https://101.jina.ai>`_ first.
+.. note:: This guide assumes you have a basic understanding of Machine Learning.
 
 .. contents:: Table of Contents
     :depth: 2
@@ -14,17 +15,23 @@ A guide on Jina Ranker Trainer
 Motivation
 --------------------
 
-In a search system, query accuracy is one of the most important aspects that will concern users. In most cases, we expect well-ordered query results to be presented.
-For one search request, we may have multiple matches and we want to have the most relevant match or top-K matches presented to users. On the other hand, we may also want to aggregate the top-K chunks to top-K matches.
+In a search system, query accuracy is one of the most important aspects that will concern users.
+In most cases, we expect well-ordered query results to be presented.
+For one search request, we may have multiple matches and we want to have the most relevant match or top-K matches presented to users.
+
+In the Information Retrieval and Machine Learning community,
+researchers has developed Learning-to-Rank technique to allow users to train a ``Ranker`` in a supervised fashion.
+In this guide, we will introduce how to train your ranker with Jina Ranker Trainer.
 
 
 Before you start
 -------------------
 
-You have installed the latest stable release of Jina Core according to the instructions found `here <https://docs.jina.ai/chapters/core/setup/index.html>`_ and read `Understand Jina Recursive Document Representation guide. <https://docs.jina.ai/chapters/traversal.html?highlight=recursive>`_
+You have installed the latest stable release of Jina Core according to the instructions found `here <https://docs.jina.ai/chapters/core/setup/index.html>`_.
 
 Overview
 -----------------
+
 
 
 

--- a/chapters/ranker_trainer.rst
+++ b/chapters/ranker_trainer.rst
@@ -60,8 +60,35 @@ In `Jina Hub <https://github.com/jina-ai/jina-hub/tree/master/rankers/LightGBMRa
 In this guideline, we'll demonstrate a simple use case: Optimize the ranking for a online shopping website:
 
 Imaging you're running a online-mall sells shoes, and you want to optimize your product ranking using a list of three features:
-`price`, `brand` and `stock_number`.
+`price`, `brand` and `color`.
 The labels are collected `num_clicks` in the past month.
+Your training data might looks like this:
+
+.. list-table:: List of Jina Data Types
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - price
+     - brand
+     - color
+     - num_clicks
+   * - 100
+     - nike
+     - white
+     - 768
+   * - 600
+     - addidas
+     - red
+     - 54
+   * - 68
+     - asics
+     - black
+     - 691
+   * - ...
+     - ...
+     - ...
+     - ...
+
 
 
 

--- a/chapters/ranker_trainer.rst
+++ b/chapters/ranker_trainer.rst
@@ -125,9 +125,7 @@ While using it, please pass the feature names and label name as well as the para
 
 The meaning of these parameters are:
 
-* ``model_path``: The model you want to optimize, if the ``model_path`` does not exist,
-the ranker trainer will train the model from scratch.
-Otherwise will train the model in an incremental manner.
+* ``model_path``: The model you want to optimize, if the ``model_path`` does not exist, the ranker trainer will train the model from scratch. Otherwise will train the model in an incremental manner.
 * ``query_feature_names``: Feature names used to extract from query ``Documents``.
 * ``match_feature_names``: Feature names used to extract from match ``Documents``.
 * ``label_feature_name``: Feature name used to train the model as label.

--- a/chapters/ranker_trainer.rst
+++ b/chapters/ranker_trainer.rst
@@ -1,0 +1,43 @@
+===============================
+A guide on Jina Ranker Trainer
+===============================
+
+.. meta::
+   :description: A guide on Jina Ranker Trainer
+   :keywords: Jina, Ranker Trainer
+
+.. note:: This guide assumes you have a basic understanding of Jina, if you haven't, please check out `Jina 101 <https://101.jina.ai>`_ first.
+
+.. contents:: Table of Contents
+    :depth: 2
+
+Motivation
+--------------------
+
+In a search system, query accuracy is one of the most important aspects that will concern users. In most cases, we expect well-ordered query results to be presented.
+For one search request, we may have multiple matches and we want to have the most relevant match or top-K matches presented to users. On the other hand, we may also want to aggregate the top-K chunks to top-K matches.
+
+
+Before you start
+-------------------
+
+You have installed the latest stable release of Jina Core according to the instructions found `here <https://docs.jina.ai/chapters/core/setup/index.html>`_ and read `Understand Jina Recursive Document Representation guide. <https://docs.jina.ai/chapters/traversal.html?highlight=recursive>`_
+
+Overview
+-----------------
+
+
+
+
+
+Conclusion
+-----------------
+
+In this guide, we introduced why we need :term:`Rankers` and how to use them. Apart from that, we provided some concrete examples of :term:`Rankers` in use.
+
+What's next
+-----------------
+
+If you still have questions, feel free to `submit an issue <https://github.com/jina-ai/jina/issues>`_ or post a message in our `community slack channel <https://slack.jina.ai>`_ .
+
+To gain a deeper knowledge of the implementation of Jina Ranker, you can find the source code `here <https://github.com/jina-ai/jina/tree/master/jina/executors/rankers>`_.

--- a/chapters/ranker_trainer.rst
+++ b/chapters/ranker_trainer.rst
@@ -17,7 +17,7 @@ In most cases, we expect well-ordered query results to be presented.
 For one search request, we may have multiple matches and we want to have the most relevant match or top-K matches presented to users.
 
 In the Information Retrieval and Machine Learning community,
-researchers has developed Learning-to-Rank technique to allow users to train a ``Ranker`` in a supervised fashion.
+researchers have developed the Learning-to-Rank technique to allow users to train a ``Ranker`` in a supervised fashion.
 In this guide, we will introduce how to train your ``Ranker`` with Jina ``RankerTrainer``.
 
 
@@ -32,23 +32,23 @@ Before you start
 Overview
 -----------------
 
-Imaging you are a data scientist, and working on building a model to predict the house price.
+Imagine you are a data scientist, and working on building a model to predict the house price.
 You collected historical property selling price,
-for each property you designed a list of features, such as #bedrooms, #size, #primary schools near property, #supermarkets near property etc.
+for each property, you designed a list of features, such as #bedrooms, #size, #primary schools near the property, #supermarkets near the property, etc.
 Equipped with labels (house price) and features,
 you trained a regression model to predict the house price.
 
 The idea also applies to Search/Retrieval,
 usually referred to Learning-to-Rank.
-The features can be the score of Bm25, #tokens in the document, #links in the document etc,
+The features can be the score of Bm25, #tokens in the document, #links in the document, etc,
 the labels are the user annotated relevance score.
-Thus we can train a supervised model to optimise the ``Ranker``.
+Thus we can train a supervised model to optimize the ``Ranker``.
 
 In Jina, we created a new type of ``Executor`` named ``RankerTrainer``.
-The ``RankerTrainer`` needs user to implement a `train` and a `save` method.
+The ``RankerTrainer`` needs a user to implement a `train` and a `save` method.
 The ``train`` method takes a machine learning model to train the ``Ranker``,
-and ``save`` method saves the re-trained model into a directory.
-This feature could be beneficial to continuously improve our ranking model in an incremental manner.
+and the ``save`` method saves the re-trained model into a directory.
+This feature could be beneficial to continuously improve our ranking model incrementally.
 
 Ranker Trainer in Action: Optimize a LightGBMRanker
 ---------------------------------------------------
@@ -56,14 +56,14 @@ Ranker Trainer in Action: Optimize a LightGBMRanker
 Context
 ^^^^^^^
 
-`LightGBM <https://lightgbm.readthedocs.io/en/latest/index.html#>`_ is a gradient boosting framework that uses tree based learning algorithms.
-One of LightGBM's application is optimize Ranking using the algorithm ``LambdaRank`` to optimize ``nDCG``.
+`LightGBM <https://lightgbm.readthedocs.io/en/latest/index.html#>`_ is a gradient boosting framework that uses tree-based learning algorithms.
+One of LightGBM's applications is optimize Ranking using the algorithm ``LambdaRank`` to optimize ``nDCG``.
 
 In `Jina Hub <https://github.com/jina-ai/jina-hub/tree/master/rankers/LightGBMRanker>`_, we've created the ``LightGBMRanker``, which allows you to load a LightGBM model with Jina.
 In this guideline, we'll demonstrate a simple use case: Optimize the ranking for a online shopping website:
 
-Imaging you're running a online-mall sells shoes, and you want to optimize your product ranking using a list of three features:
-`price`, `brand` and `color`.
+Imagine you're running a online mall that sells shoes, and you want to optimize your product ranking using a list of three features:
+`price`, `brand`, and `color`.
 The labels are collected `num_clicks` in the past month.
 Your training data might looks like this:
 
@@ -125,10 +125,10 @@ While using it, please pass the feature names and label name as well as the para
 
 The meaning of these parameters are:
 
-* ``model_path``: The model you want to optimize, if the ``model_path`` does not exist, the ranker trainer will train the model from scratch. Otherwise will train the model in an incremental manner.
-* ``query_feature_names``: Feature names used to extract from query ``Documents``.
+* ``model_path``: The model you want to optimize, if the ``model_path`` does not exist, the ranker trainer will train the model from scratch. Otherwise will incrementally train the model.
+* ``query_feature_names``: Feature names are used to extract from query ``Documents``.
 * ``match_feature_names``: Feature names used to extract from match ``Documents``.
-* ``label_feature_name``: Feature name used to train the model as label.
+* ``label_feature_name``: Feature name used to train the model as the label.
 
 Use this ``Executor`` will trigger ``train`` to use LightGBM to train the model and ``save`` the trained/re-trained model into ``model_path`` as was defined in YAML.
 

--- a/chapters/ranker_trainer.rst
+++ b/chapters/ranker_trainer.rst
@@ -53,6 +53,20 @@ This feature could be beneficial to continuously improve our ranking model in an
 Ranker Trainer in Action: Optimize a LightGBMRanker
 ---------------------------------------------------
 
+`LightGBM <https://lightgbm.readthedocs.io/en/latest/index.html#>`_ is a gradient boosting framework that uses tree based learning algorithms.
+One of LightGBM's application is optimize Ranking using the algorithm ``LambdaRank`` to optimize ``nDCG``.
+
+In `Jina Hub <https://github.com/jina-ai/jina-hub/tree/master/rankers/LightGBMRanker>`_, we've created the ``LightGBMRanker``, which allows you to load a LightGBM model with Jina.
+In this guideline, we'll demonstrate a simple use case: Optimize the ranking for a online shopping website:
+
+Imaging you're running a online-mall sells shoes, and you want to optimize your product ranking using a list of three features:
+`price`, `brand` and `stock_number`.
+The labels are collected `num_clicks` in the past month.
+
+
+
+
+
 
 
 What's next

--- a/chapters/ranker_trainer.rst
+++ b/chapters/ranker_trainer.rst
@@ -53,6 +53,9 @@ This feature could be beneficial to continuously improve our ranking model in an
 Ranker Trainer in Action: Optimize a LightGBMRanker
 ---------------------------------------------------
 
+Context
+^^^^^^^
+
 `LightGBM <https://lightgbm.readthedocs.io/en/latest/index.html#>`_ is a gradient boosting framework that uses tree based learning algorithms.
 One of LightGBM's application is optimize Ranking using the algorithm ``LambdaRank`` to optimize ``nDCG``.
 
@@ -89,6 +92,23 @@ Your training data might looks like this:
      - ...
      - ...
 
+Organize You Training Data
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The features and labels to train the model should be stored in `tags` in a Jina `Document`.
+For example:
+
+.. highlight:: python
+.. code-block:: python
+
+    from jina import Document
+
+    d1 = Document(tags={'price': 100, 'brand': 'nike', 'color': 'white', 'num_clicks': 768})
+    d2 = Document(tags={'price': 600, 'brand': 'addidas', 'color': 'red', 'num_clicks': 54})
+    d3 = Document(tags={'price': 68, 'brand': 'asics', 'color': 'black', 'num_clicks': 691})
+
+Train your model using LightGBMRankerTrainer
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 


### PR DESCRIPTION
Add `RankerTrainer` documentation

The documentation is available [here](https://deploy-preview-276--jina-docs.netlify.app/chapters/ranker_trainer/).